### PR TITLE
Bumped Shipkit to 0.9.58

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     maven { url "https://plugins.gradle.org/m2/" }
   }
   dependencies {
-    classpath "org.shipkit:shipkit:0.9.39"
+    classpath "org.shipkit:shipkit:0.9.58"
   }
 }
 


### PR DESCRIPTION
This way I can pick up the fix for identifying Git origin repository (https://github.com/mockito/shipkit/pull/379)