### PR TITLE
Fixed problem with 'downstreamUpgrade' task of Shipkit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     maven { url "https://plugins.gradle.org/m2/" }
   }
   dependencies {
-    classpath "org.shipkit:shipkit:0.9.58"
+    classpath "org.shipkit:shipkit:0.9.60"
   }
 }
 

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -29,3 +29,7 @@ afterEvaluate {
     - Release notes:      TODO"""
     }
 }
+
+//Below is not essential but it is useful for Shipkit developers
+//because Travis/Shipkit will use it to automatically send pull requests with version bumps of Shipkit
+apply plugin: 'org.shipkit.upgrade-dependency'


### PR DESCRIPTION
- Adding this plugin allows Shipkit project to automatically send PRs to this project with version bumps of Shipkit. See: https://github.com/mockito/shipkit/issues/390
- Bumped Shipkit